### PR TITLE
Loosen Sidekiq dependency constraint to allow upgrade

### DIFF
--- a/sidekiq-gelf.gemspec
+++ b/sidekiq-gelf.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "gelf", '>= 1.4'
-  s.add_dependency "sidekiq", '~> 3'
+  s.add_dependency "sidekiq", '> 3'
 
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
First of all: thanks for the great project! This is really neat and clean and saved me from writing a hacky solution myself :)

While trying to upgrade to Sidekiq 4.x I ran into the problem that sidekiq-gelf-rb was stopping bundler from upgrading Sidekiq, since the dependency is defined as `~> 3`, which doesn't include Sidekiq 4.x.

After checking the current Sidekiq code, the documentation for Sidekiq middlewares and running it locally with some debug statements I think this gem still works perfectly fine with Sidekiq 4.x.

And this change loosens the dependency definition so it's possible to upgrade to Sidekiq 4.x. 

What do you think?