### PR TITLE
Use separate GELF::Logger in each thread

### DIFF
--- a/lib/sidekiq-gelf/middleware.rb
+++ b/lib/sidekiq-gelf/middleware.rb
@@ -61,7 +61,7 @@ module Sidekiq
         end
 
         def logger
-          @logger ||= ::GELF::Logger.new(*@args)
+          Thread.current[:sidekiq_gelf_logger] ||= ::GELF::Logger.new(*@args)
         end
 
         private


### PR DESCRIPTION
This changes the middleware to use a separate instance of `GELF::Logger` in each thread. The reason is that `GELF::Logger` is not thread-safe (`UDPSender` itself might not be threadsafe). See [this discussion for more details](https://github.com/Graylog2/gelf-rb/issues/29). We're running into the same problem describe in the issue.

Now, we could wait until the issue is resolved in `gelf-rb` which would make `sidekiq-gelf-rb` thread-safe again. But since the `gelf-rb` code is rather complex in regards to instance variable handling, I'd rather fix the issue in `sidekiq-gelf-rb` by making the logger thread-safe in the context it is used.

What do you think?